### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.9, '3.10', 'pypy3.10', pypy3.11, graalpy-24.1,
+        python-version: [3.9, '3.10', 'pypy3.10', pypy3.11, graalpy-24.2,
                          3.11, 3.12, 3.13, 3.13t, 3.14]
     runs-on: ubuntu-24.04
     env:

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ has been tested with CPython 3.9 through 3.14 and for PyPy 3.10 and 3.11.
 
 This module can be used as a gmpy2/python-flint replacement to provide
 CPython-compatible integer (mpz) and rational (mpq) types.  It includes few
-functions (fac, gcd and isqrt), compatible with the stdlib's module math.
+functions (factorial, gcd and isqrt), compatible with the stdlib's module math.
 
 Releases are available in the Python Package Index (PyPI) at
 https://pypi.org/project/python-gmp/

--- a/main.c
+++ b/main.c
@@ -972,6 +972,19 @@ to_bool(PyObject *self)
 BINOP(add, PyNumber_Add)
 BINOP(sub, PyNumber_Subtract)
 BINOP(mul, PyNumber_Multiply)
+
+static mp_err
+zz_quo(const zz_t *u, const zz_t *v, zz_t *w)
+{
+    return zz_divmod(w, NULL, u, v);
+}
+
+static mp_err
+zz_rem(const zz_t *u, const zz_t *v, zz_t *w)
+{
+    return zz_divmod(NULL, w, u, v);
+}
+
 BINOP(quo, PyNumber_FloorDivide)
 BINOP(rem, PyNumber_Remainder)
 

--- a/main.c
+++ b/main.c
@@ -1140,6 +1140,18 @@ numbers:
     return res;
 }
 
+static mp_err
+zz_lshift(const zz_t *u, const zz_t *v, zz_t *w)
+{
+    if (v->negative) {
+        return MP_VAL;
+    }
+    if (v->size > 1) {
+        return MP_BUF;
+    }
+    return zz_lshift1(u, v->size ? v->digits[0] : 0, w);
+}
+
 BINOP_INT(lshift)
 BINOP_INT(rshift)
 BINOP_INT(and)

--- a/main.c
+++ b/main.c
@@ -246,7 +246,7 @@ MPZ_from_int(PyObject *obj)
     }
     else {
         res = MPZ_new(0, 0);
-        if (res && zz_from_i64(&res->z, long_export.value)) {
+        if (res && zz_from_i64(long_export.value, &res->z)) {
             PyErr_NoMemory(); /* LCOV_EXCL_LINE */
         }
     }
@@ -257,7 +257,7 @@ MPZ_from_int(PyObject *obj)
     if (!PyLong_AsInt64(obj, &value)) {
         MPZ_Object *res = MPZ_new(0, 0);
 
-        if (res && zz_from_i64(&res->z, value)) {
+        if (res && zz_from_i64(value, &res->z)) {
             PyErr_NoMemory(); /* LCOV_EXCL_LINE */
         }
         return res;
@@ -1133,7 +1133,7 @@ zz_rshift(const zz_t *u, const zz_t *v, zz_t *w)
         return MP_VAL;
     }
     if (v->size > 1) {
-        return zz_from_i64(w, u->negative ? -1 : 0);
+        return zz_from_i64(u->negative ? -1 : 0, w);
     }
     return zz_rshift1(u, v->size ? v->digits[0] : 0, w);
 }
@@ -1297,7 +1297,7 @@ get_one(PyObject *Py_UNUSED(self), void *Py_UNUSED(closure))
 {
     MPZ_Object *res = MPZ_new(0, 0);
 
-    if (res && zz_from_i64(&res->z, 1)) {
+    if (res && zz_from_i64(1, &res->z)) {
         PyErr_NoMemory(); /* LCOV_EXCL_LINE */
     }
     return (PyObject *)res;

--- a/main.c
+++ b/main.c
@@ -2035,7 +2035,7 @@ err:
     }
 
 MAKE_MPZ_UI_FUN(fac)
-MAKE_MPZ_UI_FUN(double_fac)
+MAKE_MPZ_UI_FUN(fac2)
 MAKE_MPZ_UI_FUN(fib)
 
 static PyObject *
@@ -2350,7 +2350,7 @@ static PyMethodDef gmp_functions[] = {
     {"factorial", gmp_fac, METH_O,
      ("factorial($module, n, /)\n--\n\n"
       "Find n!.")},
-    {"double_fac", gmp_double_fac, METH_O,
+    {"double_fac", gmp_fac2, METH_O,
      ("double_fac($module, n, /)\n--\n\n"
       "Return the exact double factorial (n!!) of n.")},
     {"fib", gmp_fib, METH_O,

--- a/main.c
+++ b/main.c
@@ -2347,9 +2347,9 @@ static PyMethodDef gmp_functions[] = {
     {"isqrt_rem", gmp_isqrt_rem, METH_O,
      ("isqrt_rem($module, n, /)\n--\n\n"
       "Return a 2-element tuple (s,t) such that s=isqrt(x) and t=x-s*s.")},
-    {"fac", gmp_fac, METH_O,
-     ("fac($module, n, /)\n--\n\n"
-      "Find n!.\n\nRaise a ValueError if n is negative or non-integral.")},
+    {"factorial", gmp_fac, METH_O,
+     ("factorial($module, n, /)\n--\n\n"
+      "Find n!.")},
     {"double_fac", gmp_double_fac, METH_O,
      ("double_fac($module, n, /)\n--\n\n"
       "Return the exact double factorial (n!!) of n.")},
@@ -2424,6 +2424,10 @@ gmp_exec(PyObject *m)
         Py_DECREF(gmp_info);
         return -1;
         /* LCOV_EXCL_STOP */
+    }
+    if (PyModule_AddObject(m, "fac",
+                           PyObject_GetAttrString(m, "factorial")) < 0) {
+        return -1; /* LCOV_EXCL_LINE */
     }
 
     PyObject *ns = PyDict_New();

--- a/main.c
+++ b/main.c
@@ -976,13 +976,13 @@ BINOP(mul, PyNumber_Multiply)
 static mp_err
 zz_quo(const zz_t *u, const zz_t *v, zz_t *w)
 {
-    return zz_divmod(w, NULL, u, v);
+    return zz_divmod(u, v, w, NULL);
 }
 
 static mp_err
 zz_rem(const zz_t *u, const zz_t *v, zz_t *w)
 {
-    return zz_divmod(NULL, w, u, v);
+    return zz_divmod(u, v, NULL, w);
 }
 
 BINOP(quo, PyNumber_FloorDivide)
@@ -1011,7 +1011,7 @@ nb_divmod(PyObject *self, PyObject *other)
         /* LCOV_EXCL_STOP */
     }
 
-    mp_err ret = zz_divmod(&q->z, &r->z, &u->z, &v->z);
+    mp_err ret = zz_divmod(&u->z, &v->z, &q->z, &r->z);
 
     if (ret) {
         Py_DECREF(q);
@@ -1549,7 +1549,7 @@ __round__(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         return NULL;
         /* LCOV_EXCL_STOP */
     }
-    if (zz_divmod_near(&q->z, &r->z, &u->z, &((MPZ_Object *)p)->z)) {
+    if (zz_divmod_near(&u->z, &((MPZ_Object *)p)->z, &q->z, &r->z)) {
         /* LCOV_EXCL_START */
         Py_DECREF(q);
         Py_DECREF(r);

--- a/main.c
+++ b/main.c
@@ -843,7 +843,7 @@ static PyObject *
 to_float(PyObject *self)
 {
     double d;
-    mp_err ret = zz_to_double(&((MPZ_Object *)self)->z, 0, &d);
+    mp_err ret = zz_to_double(&((MPZ_Object *)self)->z, &d);
 
     if (ret == MP_BUF) {
         PyErr_SetString(PyExc_OverflowError,

--- a/main.c
+++ b/main.c
@@ -122,7 +122,7 @@ MPZ_new(mp_size_t size, bool negative)
 
     if (global.gmp_cache_size && size <= MAX_CACHE_MPZ_LIMBS) {
         res = global.gmp_cache[--(global.gmp_cache_size)];
-        if (SZ(res) < size && zz_resize(&res->z, size) == MP_MEM) {
+        if (SZ(res) < size && zz_resize(size, &res->z) == MP_MEM) {
             /* LCOV_EXCL_START */
             global.gmp_cache[(global.gmp_cache_size)++] = res;
             return (MPZ_Object *)PyErr_NoMemory();
@@ -136,7 +136,7 @@ MPZ_new(mp_size_t size, bool negative)
         if (!res) {
             return NULL; /* LCOV_EXCL_LINE */
         }
-        if (zz_init(&res->z) || zz_resize(&res->z, size)) {
+        if (zz_init(&res->z) || zz_resize(size, &res->z)) {
             return (MPZ_Object *)PyErr_NoMemory(); /* LCOV_EXCL_LINE */
         }
     }
@@ -551,7 +551,7 @@ new(PyTypeObject *type, PyObject *args, PyObject *keywds)
             /* LCOV_EXCL_STOP */
         }
         ISNEG(newobj) = ISNEG(tmp);
-        if (zz_init(&newobj->z) || zz_resize(&newobj->z, n)) {
+        if (zz_init(&newobj->z) || zz_resize(n, &newobj->z)) {
             /* LCOV_EXCL_START */
             Py_DECREF(tmp);
             return PyErr_NoMemory();
@@ -1812,7 +1812,7 @@ gmp_gcd(PyObject *Py_UNUSED(module), PyObject *const *args, Py_ssize_t nargs)
         Py_DECREF(arg);
         Py_SETREF(res, tmp);
     }
-    if (zz_resize(&res->z, SZ(res)) == MP_MEM) {
+    if (zz_resize(SZ(res), &res->z) == MP_MEM) {
         /* LCOV_EXCL_START */
         Py_DECREF(res);
         return PyErr_NoMemory();

--- a/main.c
+++ b/main.c
@@ -1152,6 +1152,18 @@ zz_lshift(const zz_t *u, const zz_t *v, zz_t *w)
     return zz_lshift1(u, v->size ? v->digits[0] : 0, w);
 }
 
+static mp_err
+zz_rshift(const zz_t *u, const zz_t *v, zz_t *w)
+{
+    if (v->negative) {
+        return MP_VAL;
+    }
+    if (v->size > 1) {
+        return zz_from_i64(w, u->negative ? -1 : 0);
+    }
+    return zz_rshift1(u, v->size ? v->digits[0] : 0, w);
+}
+
 BINOP_INT(lshift)
 BINOP_INT(rshift)
 BINOP_INT(and)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ ignore = [
 lines-after-imports = 2
 
 [tool.cibuildwheel]
-enable = "pypy cpython-prerelease cpython-freethreading"
+enable = "pypy cpython-prerelease cpython-freethreading graalpy"
 skip = "*-win32 *-manylinux_i686 *-musllinux_* *-manylinux_armv7l pp*aarch64*"
 before-all = "bash scripts/cibw_before_all.sh"
 test-extras = "tests"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from datetime import timedelta
 
 import gmp
@@ -10,7 +11,11 @@ settings.register_profile("default",
                           settings(default,
                                    deadline=timedelta(seconds=300)))
 ci = settings.get_profile("ci")
-settings.register_profile("ci", settings(ci, max_examples=10000))
+if platform.python_implementation() != "GraalVM":
+    ci = settings(ci, max_examples=10000)
+else:
+    ci = settings(ci, max_examples=1000)
+settings.register_profile("ci", ci)
 
 def pytest_report_header(config):
     print(f"""

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,6 +6,7 @@ from gmp import (
     _mpmath_normalize,
     double_fac,
     fac,
+    factorial,
     fib,
     gcd,
     gcdext,
@@ -56,8 +57,8 @@ def test_fib(x):
 def test_fac(x):
     mx = mpz(x)
     r = math.factorial(x)
-    assert fac(mx) == r
-    assert fac(x) == r
+    assert factorial(mx) == r
+    assert factorial(x) == r
 
 
 @given(integers(), integers())
@@ -138,6 +139,7 @@ def test__mpmath_create(man, exp, prec, rnd):
 
 def test_interfaces():
     assert gcd() == 0
+    assert factorial(123) == fac(123)
     with pytest.raises(TypeError):
         gcd(1j)
     with pytest.raises(TypeError):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -21,7 +21,8 @@ from hypothesis.strategies import booleans, integers, sampled_from
 def test_isqrt(x):
     mx = mpz(x)
     r = math.isqrt(x)
-    assert isqrt(mx) == isqrt(x) == r
+    assert isqrt(mx) == r
+    assert isqrt(x) == r
 
 
 @given(integers(min_value=0))
@@ -29,7 +30,8 @@ def test_isqrt_rem(x):
     mpmath = pytest.importorskip("mpmath")
     mx = mpz(x)
     r = mpmath.libmp.libintmath.sqrtrem_python(x)
-    assert isqrt_rem(mx) == isqrt_rem(x) == r
+    assert isqrt_rem(mx) == r
+    assert isqrt_rem(x) == r
 
 
 @given(integers(min_value=0, max_value=12345))
@@ -37,7 +39,8 @@ def test_double_fac(x):
     mpmath = pytest.importorskip("mpmath")
     mx = mpz(x)
     r = mpmath.libmp.libintmath.ifac2_python(x)
-    assert double_fac(mx) == double_fac(x) == r
+    assert double_fac(mx) == r
+    assert double_fac(x) == r
 
 
 @given(integers(min_value=0, max_value=12345))
@@ -45,14 +48,16 @@ def test_fib(x):
     mpmath = pytest.importorskip("mpmath")
     mx = mpz(x)
     r = mpmath.libmp.libintmath.ifib_python(x)
-    assert fib(mx) == fib(x) == r
+    assert fib(mx) == r
+    assert fib(x) == r
 
 
 @given(integers(min_value=0, max_value=12345))
 def test_fac(x):
     mx = mpz(x)
     r = math.factorial(x)
-    assert fac(mx) == fac(x) == r
+    assert fac(mx) == r
+    assert fac(x) == r
 
 
 @given(integers(), integers())

--- a/tests/test_outofmem.py
+++ b/tests/test_outofmem.py
@@ -12,6 +12,8 @@ if platform.system() != "Linux":
 if platform.python_implementation() == "GraalVM":
     pytest.skip("XXX: module 'resource' has no attribute 'setrlimit'",
                 allow_module_level=True)
+if platform.python_implementation() == "PyPy":
+    pytest.skip("XXX: diofant/python-gmp#73", allow_module_level=True)
 
 resource = pytest.importorskip("resource")
 

--- a/zz.c
+++ b/zz.c
@@ -831,18 +831,6 @@ err:
 }
 
 mp_err
-zz_quo(const zz_t *u, const zz_t *v, zz_t *w)
-{
-    return zz_divmod(w, NULL, u, v);
-}
-
-mp_err
-zz_rem(const zz_t *u, const zz_t *v, zz_t *w)
-{
-    return zz_divmod(NULL, w, u, v);
-}
-
-mp_err
 zz_rshift1(const zz_t *u, mp_limb_t rshift, zz_t *v)
 {
     if (!u->size) {
@@ -1572,7 +1560,7 @@ zz_gcdext(const zz_t *u, const zz_t *v, zz_t *g, zz_t *s, zz_t *t)
         zz_t tmp;
 
         if (zz_init(&tmp) || zz_mul(u, tmp_s, &tmp)
-            || zz_sub(tmp_g, &tmp, &tmp) || zz_quo(&tmp, v, &tmp)
+            || zz_sub(tmp_g, &tmp, &tmp) || zz_divmod(&tmp, NULL, &tmp, v)
             || zz_resize(t, tmp.size) == MP_MEM)
         {
             /* LCOV_EXCL_START */
@@ -1740,7 +1728,9 @@ zz_powm(const zz_t *u, const zz_t *v, const zz_t *w, zz_t *res)
     if (u->negative || u->size > w->size) {
         zz_t tmp;
 
-        if (zz_init(&tmp) || zz_rem(u, w, &tmp) || zz_copy(&tmp, &o1)) {
+        if (zz_init(&tmp) || zz_divmod(NULL, &tmp, u, w)
+            || zz_copy(&tmp, &o1))
+        {
             /* LCOV_EXCL_START */
             zz_clear(&tmp);
             goto end3;

--- a/zz.c
+++ b/zz.c
@@ -1842,5 +1842,5 @@ zz_sqrtrem(const zz_t *u, zz_t *v, zz_t *w)
     }
 
 MK_ZZ_FUNC_UL(fac, fac_ui)
-MK_ZZ_FUNC_UL(double_fac, 2fac_ui)
+MK_ZZ_FUNC_UL(fac2, 2fac_ui)
 MK_ZZ_FUNC_UL(fib, fib_ui)

--- a/zz.c
+++ b/zz.c
@@ -717,7 +717,7 @@ zz_mul(const zz_t *u, const zz_t *v, zz_t *w)
 }
 
 mp_err
-zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
+zz_divmod(const zz_t *u, const zz_t *v, zz_t *q, zz_t *r)
 {
     if (!v->size) {
         return MP_VAL;
@@ -730,7 +730,7 @@ zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
                 return MP_MEM;  /* LCOV_EXCL_LINE */
             }
 
-            mp_err ret = zz_divmod(&tmp, r, u, v);
+            mp_err ret = zz_divmod(u, v, &tmp, r);
 
             zz_clear(&tmp);
             return ret;
@@ -742,7 +742,7 @@ zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
                 return MP_MEM;  /* LCOV_EXCL_LINE */
             }
 
-            mp_err ret = zz_divmod(q, &tmp, u, v);
+            mp_err ret = zz_divmod(u, v, q, &tmp);
 
             zz_clear(&tmp);
             return ret;
@@ -776,7 +776,7 @@ zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
                 /* LCOV_EXCL_STOP */
             }
 
-            mp_err ret = zz_divmod(q, r, &tmp, v);
+            mp_err ret = zz_divmod(&tmp, v, q, r);
 
             zz_clear(&tmp);
             return ret;
@@ -791,7 +791,7 @@ zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
                 /* LCOV_EXCL_STOP */
             }
 
-            mp_err ret = zz_divmod(q, r, u, &tmp);
+            mp_err ret = zz_divmod(u, &tmp, q, r);
 
             zz_clear(&tmp);
             return ret;
@@ -915,12 +915,12 @@ zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v)
 
 
 mp_err
-zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
+zz_divmod_near(const zz_t *u, const zz_t *v, zz_t *q, zz_t *r)
 {
     mp_ord unexpect = v->negative ? MP_LT : MP_GT;
     zz_t halfQ;
 
-    if (zz_divmod(q, r, u, v) || zz_init(&halfQ) || zz_rshift1(v, 1, &halfQ)) {
+    if (zz_divmod(u, v, q, r) || zz_init(&halfQ) || zz_rshift1(v, 1, &halfQ)) {
         /* LCOV_EXCL_START */
     err:
         zz_clear(q);
@@ -1035,7 +1035,7 @@ zz_truediv(const zz_t *u, const zz_t *v, double *res)
 
     zz_t c, d;
 
-    if (zz_init(&c) || zz_init(&d) || zz_divmod_near(&c, &d, a, b)) {
+    if (zz_init(&c) || zz_init(&d) || zz_divmod_near(a, b, &c, &d)) {
         /* LCOV_EXCL_START */
         zz_clear(a);
         zz_clear(b);
@@ -1560,7 +1560,7 @@ zz_gcdext(const zz_t *u, const zz_t *v, zz_t *g, zz_t *s, zz_t *t)
         zz_t tmp;
 
         if (zz_init(&tmp) || zz_mul(u, tmp_s, &tmp)
-            || zz_sub(tmp_g, &tmp, &tmp) || zz_divmod(&tmp, NULL, &tmp, v)
+            || zz_sub(tmp_g, &tmp, &tmp) || zz_divmod(&tmp, v, &tmp, NULL)
             || zz_resize(t, tmp.size) == MP_MEM)
         {
             /* LCOV_EXCL_START */
@@ -1728,7 +1728,7 @@ zz_powm(const zz_t *u, const zz_t *v, const zz_t *w, zz_t *res)
     if (u->negative || u->size > w->size) {
         zz_t tmp;
 
-        if (zz_init(&tmp) || zz_divmod(NULL, &tmp, u, w)
+        if (zz_init(&tmp) || zz_divmod(u, w, NULL, &tmp)
             || zz_copy(&tmp, &o1))
         {
             /* LCOV_EXCL_START */

--- a/zz.c
+++ b/zz.c
@@ -663,6 +663,36 @@ zz_mul(const zz_t *u, const zz_t *v, zz_t *w)
     if (!v->size) {
         return zz_from_i64(w, 0);
     }
+    if (u == w) {
+        zz_t tmp;
+
+        if (zz_init(&tmp) || zz_copy(u, &tmp)) {
+            /* LCOV_EXCL_START */
+            zz_clear(&tmp);
+            return MP_MEM;
+            /* LCOV_EXCL_STOP */
+        }
+
+        mp_err ret = zz_mul(&tmp, v, w);
+
+        zz_clear(&tmp);
+        return ret;
+    }
+    if (v == w) {
+        zz_t tmp;
+
+        if (zz_init(&tmp) || zz_copy(v, &tmp)) {
+            /* LCOV_EXCL_START */
+            zz_clear(&tmp);
+            return MP_MEM;
+            /* LCOV_EXCL_STOP */
+        }
+
+        mp_err ret = zz_mul(u, &tmp, w);
+
+        zz_clear(&tmp);
+        return ret;
+    }
     if (zz_resize(w, u->size + v->size) || TMP_OVERFLOW) {
         return MP_MEM; /* LCOV_EXCL_LINE */
     }

--- a/zz.c
+++ b/zz.c
@@ -841,18 +841,6 @@ zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v)
 }
 
 mp_err
-zz_lshift(const zz_t *u, const zz_t *v, zz_t *w)
-{
-    if (v->negative) {
-        return MP_VAL;
-    }
-    if (v->size > 1) {
-        return MP_BUF;
-    }
-    return zz_lshift1(u, v->size ? v->digits[0] : 0, w);
-}
-
-mp_err
 zz_rshift(const zz_t *u, const zz_t *v, zz_t *w)
 {
     if (v->negative) {

--- a/zz.c
+++ b/zz.c
@@ -391,8 +391,8 @@ err:
     return MP_VAL;
 }
 
-mp_err
-zz_to_double(const zz_t *u, mp_size_t shift, double *d)
+static mp_err
+_zz_to_double(const zz_t *u, mp_size_t shift, double *d)
 {
     mp_limb_t high = 1ULL << DBL_MANT_DIG;
     mp_limb_t man = 0, carry, left;
@@ -470,6 +470,12 @@ done:
         return MP_BUF;
     }
     return MP_OK;
+}
+
+mp_err
+zz_to_double(const zz_t *u, double *d)
+{
+    return _zz_to_double(u, 0, d);
 }
 
 #define SWAP(T, a, b) \
@@ -984,7 +990,7 @@ zz_truediv(const zz_t *u, const zz_t *v, double *res)
     zz_clear(b);
     zz_clear(&d);
 
-    mp_err ret = zz_to_double(&c, shift, res);
+    mp_err ret = _zz_to_double(&c, shift, res);
 
     zz_clear(&c);
     if (u->negative != v->negative) {

--- a/zz.c
+++ b/zz.c
@@ -765,6 +765,11 @@ zz_rem(const zz_t *u, const zz_t *v, zz_t *w)
 mp_err
 zz_rshift1(const zz_t *u, mp_limb_t rshift, zz_t *v)
 {
+    if (!u->size) {
+        v->size = 0;
+        return MP_OK;
+    }
+
     mp_size_t whole = rshift / GMP_NUMB_BITS;
     mp_size_t size = u->size;
 
@@ -840,28 +845,6 @@ zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v)
     return MP_OK;
 }
 
-mp_err
-zz_rshift(const zz_t *u, const zz_t *v, zz_t *w)
-{
-    if (v->negative) {
-        return MP_VAL;
-    }
-    if (!u->size) {
-        return zz_from_i64(w, 0);
-    }
-    if (!v->size) {
-        return zz_copy(u, w);
-    }
-    if (v->size > 1) {
-        if (u->negative) {
-            return zz_from_i64(w, -1);
-        }
-        else {
-            return zz_from_i64(w, 0);
-        }
-    }
-    return zz_rshift1(u, v->digits[0], w);
-}
 
 mp_err
 zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)

--- a/zz.c
+++ b/zz.c
@@ -852,20 +852,11 @@ mp_err
 zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
 {
     mp_ord unexpect = v->negative ? MP_LT : MP_GT;
-    mp_err ret = zz_divmod(q, r, u, v);
-
-    if (ret) {
-        /* LCOV_EXCL_START */
-        zz_clear(q);
-        zz_clear(r);
-        return ret;
-        /* LCOV_EXCL_STOP */
-    }
-
     zz_t halfQ;
 
-    if (zz_init(&halfQ) || zz_rshift1(v, 1, &halfQ)) {
+    if (zz_divmod(q, r, u, v) || zz_init(&halfQ) || zz_rshift1(v, 1, &halfQ)) {
         /* LCOV_EXCL_START */
+    err:
         zz_clear(q);
         zz_clear(r);
         return MP_MEM;
@@ -881,13 +872,7 @@ zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
     if (cmp == unexpect) {
         zz_t one;
 
-        if (zz_init(&one) || zz_from_i64(&one, 1)) {
-            /* LCOV_EXCL_START */
-            zz_clear(&one);
-            goto err;
-            /* LCOV_EXCL_STOP */
-        }
-        if (zz_add(q, &one, q)) {
+        if (zz_init(&one) || zz_from_i64(&one, 1) || zz_add(q, &one, q)) {
             /* LCOV_EXCL_START */
             zz_clear(&one);
             goto err;
@@ -899,12 +884,6 @@ zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v)
         }
     }
     return MP_OK;
-err:
-    /* LCOV_EXCL_START */
-    zz_clear(q);
-    zz_clear(r);
-    return MP_MEM;
-    /* LCOV_EXCL_STOP */
 }
 
 mp_err

--- a/zz.h
+++ b/zz.h
@@ -56,12 +56,12 @@ mp_err zz_sub(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_mul(const zz_t *u, const zz_t *v, zz_t *w);
 
-mp_err zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v);
+mp_err zz_divmod(const zz_t *u, const zz_t *v, zz_t *q, zz_t *r);
 
 mp_err zz_rshift1(const zz_t *u, mp_limb_t rshift, zz_t *v);
 mp_err zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v);
 
-mp_err zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v);
+mp_err zz_divmod_near(const zz_t *u, const zz_t *v, zz_t *q, zz_t *r);
 mp_err zz_truediv(const zz_t *u, const zz_t *v, double *res);
 
 mp_err zz_invert(const zz_t *u, zz_t *v);
@@ -71,13 +71,13 @@ mp_err zz_xor(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_pow(const zz_t *u, const zz_t *v, zz_t *w);
 
-mp_err zz_gcd(const zz_t *u, const zz_t *v, zz_t *gcd);
+mp_err zz_gcd(const zz_t *u, const zz_t *v, zz_t *w);
 mp_err zz_gcdext(const zz_t *u, const zz_t *v, zz_t *g, zz_t *s, zz_t *t);
 mp_err zz_inverse(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_powm(const zz_t *u, const zz_t *v, const zz_t *w, zz_t *res);
 
-mp_err zz_sqrtrem(const zz_t *u, zz_t *root, zz_t *rem);
+mp_err zz_sqrtrem(const zz_t *u, zz_t *v, zz_t *w);
 
 mp_err zz_fac_ul(const zz_t *u, zz_t *v);
 mp_err zz_double_fac_ul(const zz_t *u, zz_t *v);

--- a/zz.h
+++ b/zz.h
@@ -20,7 +20,7 @@ typedef enum {
 } mp_err;
 
 mp_err zz_init(zz_t *u);
-mp_err zz_resize(zz_t *u, mp_size_t size);
+mp_err zz_resize(mp_size_t size, zz_t *u);
 void zz_clear(zz_t *u);
 void zz_normalize(zz_t *u);
 

--- a/zz.h
+++ b/zz.h
@@ -44,7 +44,7 @@ extern int OPT_TAG, OPT_PREFIX;
 mp_err zz_to_str(const zz_t *u, int base, int options, char **buf);
 mp_err zz_from_str(const char *str, size_t len, int base, zz_t *u);
 
-mp_err zz_to_double(const zz_t *u, mp_size_t shift, double *d);
+mp_err zz_to_double(const zz_t *u, double *d);
 
 mp_err zz_to_bytes(const zz_t *u, size_t length, int is_little,
                    int is_signed, unsigned char **buffer);

--- a/zz.h
+++ b/zz.h
@@ -32,7 +32,7 @@ typedef enum {
 
 mp_ord zz_cmp(const zz_t *u, const zz_t *v);
 
-mp_err zz_from_i64(zz_t *u, int64_t v);
+mp_err zz_from_i64(int64_t u, zz_t *v);
 mp_err zz_to_i64(const zz_t *u, int64_t *v);
 
 mp_err zz_copy(const zz_t *u, zz_t *v);

--- a/zz.h
+++ b/zz.h
@@ -62,7 +62,6 @@ mp_err zz_rem(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_rshift1(const zz_t *u, mp_limb_t rshift, zz_t *v);
 mp_err zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v);
-mp_err zz_lshift(const zz_t *u, const zz_t *v, zz_t *w);
 mp_err zz_rshift(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v);

--- a/zz.h
+++ b/zz.h
@@ -57,8 +57,6 @@ mp_err zz_sub(const zz_t *u, const zz_t *v, zz_t *w);
 mp_err zz_mul(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_divmod(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v);
-mp_err zz_quo(const zz_t *u, const zz_t *v, zz_t *w);
-mp_err zz_rem(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_rshift1(const zz_t *u, mp_limb_t rshift, zz_t *v);
 mp_err zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v);

--- a/zz.h
+++ b/zz.h
@@ -80,7 +80,7 @@ mp_err zz_powm(const zz_t *u, const zz_t *v, const zz_t *w, zz_t *res);
 mp_err zz_sqrtrem(const zz_t *u, zz_t *v, zz_t *w);
 
 mp_err zz_fac_ul(const zz_t *u, zz_t *v);
-mp_err zz_double_fac_ul(const zz_t *u, zz_t *v);
+mp_err zz_fac2_ul(const zz_t *u, zz_t *v);
 mp_err zz_fib_ul(const zz_t *u, zz_t *v);
 
 #endif /* ZZ_H */

--- a/zz.h
+++ b/zz.h
@@ -62,7 +62,6 @@ mp_err zz_rem(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_rshift1(const zz_t *u, mp_limb_t rshift, zz_t *v);
 mp_err zz_lshift1(const zz_t *u, mp_limb_t lshift, zz_t *v);
-mp_err zz_rshift(const zz_t *u, const zz_t *v, zz_t *w);
 
 mp_err zz_divmod_near(zz_t *q, zz_t *r, const zz_t *u, const zz_t *v);
 mp_err zz_truediv(const zz_t *u, const zz_t *v, double *res);


### PR DESCRIPTION
 * Support in-place lshift1's
 * Remove zz_lshift()
 * Remove zz_rshift()
 * In-place zz_add/sub()
 * Cleanup zz_divmod_near()
 * Support in-place zz_copy/neg/abs()
 * Add macro for unary slots
 * Support in-place zz_invert(), cleanup binary logic ops
 * Drop shift argument from zz_to_double()
 * Support in-place zz_gcd/gcdext/sqrtrem()
 * In-place zz_mul()
 * In-place for zz_divmod()
 * Remove zz_rem/quo()
 * Fix zz_divmod/divmod_near() signatures
 * Separate asserts in tests/test_functions.py
 * Run smaller set of examples on GraalVM
 * Build GraalPy wheels
 * Update GraalPy version in build matrix
 * Support fac() as an alias for factorial()
 * Disable memory testing on PyPy
 * Fix zz_from_i64() signature
 * Fix zz_resize() signature
 * zz_double_fac_ul -> zz_fac2_ul

