### PR TITLE
Use tp_finalize slot to manage cache

### DIFF
--- a/gmp.c
+++ b/gmp.c
@@ -34,7 +34,6 @@ MPZ_new(void)
     if (global.gmp_cache_size) {
         res = global.gmp_cache[--global.gmp_cache_size];
         (void)zz_set(0, &res->z);
-        Py_XINCREF((PyObject *)res);
     }
     else {
         res = PyObject_New(MPZ_Object, &MPZ_Type);
@@ -640,14 +639,24 @@ new(PyTypeObject *type, PyObject *args, PyObject *keywds)
 }
 
 static void
-dealloc(PyObject *self)
+finalize(PyObject *self)
 {
     MPZ_Object *u = (MPZ_Object *)self;
 
     if (global.gmp_cache_size < MAX_CACHE_SIZE
-        && zz_sizeof(&u->z) <= MAX_CACHED_SIZEOF
-        && MPZ_CheckExact(self))
+        && MPZ_CheckExact(self)
+        && zz_sizeof(&u->z) <= MAX_CACHED_SIZEOF)
     {
+        Py_INCREF(self);
+    }
+}
+
+static void
+dealloc(PyObject *self)
+{
+    MPZ_Object *u = (MPZ_Object *)self;
+
+    if (PyObject_CallFinalizerFromDealloc(self)) {
         global.gmp_cache[global.gmp_cache_size++] = u;
     }
     else {
@@ -1977,6 +1986,7 @@ PyTypeObject MPZ_Type = {
     .tp_basicsize = sizeof(MPZ_Object),
     .tp_new = new,
     .tp_dealloc = dealloc,
+    .tp_finalize = finalize,
     .tp_repr = repr,
     .tp_str = str,
     .tp_richcompare = richcompare,


### PR DESCRIPTION
| Benchmark             | ref     | patch                |
|-----------------------|:-------:|:--------------------:|
| collatz0(97)          | 87.5 us | 103 us: 1.17x slower |
| collatz0(871)         | 131 us  | 154 us: 1.17x slower |
| collatz0((1<<128)+31) | 706 us  | 836 us: 1.18x slower |
| collatz1(97)          | 93.2 us | 105 us: 1.13x slower |
| collatz1(871)         | 141 us  | 159 us: 1.13x slower |
| collatz1((1<<128)+31) | 757 us  | 857 us: 1.13x slower |
| Geometric mean        | (ref)   | 1.15x slower         |

With `collatz.py` benchmark from #263 on CPython 3.14 with `--enable-optimizations`.

Bigger picture, including CACHE_SIZE=0 cases:

| Benchmark             | ref-nocache | ref                   | patch-nocache         | patch                |
|-----------------------|:-----------:|:---------------------:|:---------------------:|:--------------------:|
| collatz0(97)          | 129 us      | 87.4 us: 1.47x faster | 140 us: 1.09x slower  | 103 us: 1.25x faster |
| collatz0(871)         | 193 us      | 132 us: 1.46x faster  | 210 us: 1.09x slower  | 154 us: 1.25x faster |
| collatz0((1<<128)+31) | 1.01 ms     | 707 us: 1.43x faster  | 1.11 ms: 1.10x slower | 832 us: 1.22x faster |
| collatz1(97)          | 129 us      | 93.6 us: 1.38x faster | 143 us: 1.11x slower  | 106 us: 1.22x faster |
| collatz1(871)         | 195 us      | 140 us: 1.39x faster  | 215 us: 1.10x slower  | 159 us: 1.22x faster |
| collatz1((1<<128)+31) | 1.02 ms     | 758 us: 1.35x faster  | 1.15 ms: 1.12x slower | 857 us: 1.19x faster |
| Geometric mean        | (ref)       | 1.41x faster          | 1.10x slower          | 1.23x faster         |
