### PR TITLE
Correct overflow case for negatives in zz_get_bytes()

### DIFF
--- a/gmp.c
+++ b/gmp.c
@@ -321,10 +321,6 @@ zz_get_bytes(const zz_t *u, size_t length, bool is_signed,
         if (!is_signed) {
             return ZZ_BUF;
         }
-        if (8*length/bits_per_digit + 1 < u->size) {
-            zz_clear(&tmp);
-            return ZZ_BUF;
-        }
         if (zz_set(1, &tmp) || zz_mul_2exp(&tmp, 8*length, &tmp)
             || zz_add(&tmp, u, &tmp))
         {
@@ -338,7 +334,7 @@ zz_get_bytes(const zz_t *u, size_t length, bool is_signed,
 
     size_t nbits = zz_bitlen(u);
 
-    if (nbits > 8*length
+    if (zz_isneg(u) || nbits > 8*length
         || (is_signed && ((!nbits && is_negative)
             || (nbits && (nbits == 8 * length ? !is_negative : is_negative)))))
     {

--- a/tests/test_mpz.py
+++ b/tests/test_mpz.py
@@ -839,6 +839,7 @@ def test_methods(x):
 @example(-65281, 3, "little", True)
 @example(128, 1, "big", False)
 @example(-32383289396013590652, 0, "big", True)
+@example(-384, 1, "big", True)
 def test_to_bytes_bulk(x, length, byteorder, signed):
     try:
         rx = x.to_bytes(length, byteorder, signed=signed)


### PR DESCRIPTION
Closes #337